### PR TITLE
:bug: token creation

### DIFF
--- a/src/main/java/io/suricate/monitoring/controllers/UserController.java
+++ b/src/main/java/io/suricate/monitoring/controllers/UserController.java
@@ -59,7 +59,6 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import springfox.documentation.annotations.ApiIgnore;
 
 import java.net.URI;
-import java.security.NoSuchAlgorithmException;
 import java.security.Principal;
 import java.util.List;
 import java.util.Optional;
@@ -372,7 +371,7 @@ public class UserController {
     @PreAuthorize("hasRole('ROLE_USER')")
     public ResponseEntity<PersonalAccessTokenResponseDto> createPersonalAccessToken(@ApiIgnore Authentication authentication,
                                                                                     @ApiParam(name = "tokenRequestDto", value = "The token request", required = true)
-                                                        @RequestBody PersonalAccessTokenRequestDto personalAccessTokenRequestDto) throws NoSuchAlgorithmException {
+                                                        @RequestBody PersonalAccessTokenRequestDto personalAccessTokenRequestDto) {
         String personalAccessToken = patHelperService.createPersonalAccessToken();
         Long checksum = patHelperService.computePersonAccessTokenChecksum(personalAccessToken);
 

--- a/src/main/java/io/suricate/monitoring/services/token/PersonalAccessTokenHelperService.java
+++ b/src/main/java/io/suricate/monitoring/services/token/PersonalAccessTokenHelperService.java
@@ -2,13 +2,11 @@ package io.suricate.monitoring.services.token;
 
 import io.seruco.encoding.base62.Base62;
 import io.suricate.monitoring.properties.ApplicationProperties;
-import io.suricate.monitoring.services.api.PersonalAccessTokenService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.zip.CRC32;
 import java.util.zip.Checksum;
@@ -30,10 +28,10 @@ public class PersonalAccessTokenHelperService {
      * Create personal access token
      * @return A random string
      */
-    public String createPersonalAccessToken() throws NoSuchAlgorithmException {
+    public String createPersonalAccessToken() {
         // Generate Base62 string of 32 chars length
         byte[] bytes = new byte[24];
-        SecureRandom.getInstanceStrong().nextBytes(bytes);
+        new SecureRandom().nextBytes(bytes);
 
         Base62 base62 = Base62.createInstance();
         final String randomString = new String(base62.encode(bytes));


### PR DESCRIPTION
### Description

While deploying Suricate on Openshift with the Official Docker image, sometimes the token generation was not working (process of creation taking way too much time).

After building a new image with more logs, I've found out that the issue was coming from `SecureRandom.getInstanceStrong().nextBytes(bytes);`

After a bit of research, I found out those 2 bugs on OpenJDK https://bugs.openjdk.org/browse/JDK-6708214 & https://bugs.openjdk.org/browse/JDK-6202721.

The mentioned workaround is to use `new SecureRandom()` instead of `SecureRandom.getInstanceStrong()`. I've tested it and it works completely fine now
