### PR TITLE
:lock: Change on authorization role for getAll and getOne

### DIFF
--- a/src/main/java/io/suricate/monitoring/controllers/UserController.java
+++ b/src/main/java/io/suricate/monitoring/controllers/UserController.java
@@ -132,7 +132,7 @@ public class UserController {
     })
     @ApiPageable
     @GetMapping(value = "/v1/users")
-    @PreAuthorize("hasRole('ROLE_USER')")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public Page<UserResponseDto> getAll(@ApiParam(name = "search", value = "Search keyword")
                                         @RequestParam(value = "search", required = false) String search,
                                         Pageable pageable) {
@@ -152,7 +152,7 @@ public class UserController {
         @ApiResponse(code = 403, message = "You don't have permission to access to this resource", response = ApiErrorDto.class)
     })
     @GetMapping(value = "/v1/users/{userId}")
-    @PreAuthorize("hasRole('ROLE_USER')")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public ResponseEntity<UserResponseDto> getOne(@ApiParam(name = "userId", value = "The user id", required = true, example = "1")
                                                   @PathVariable("userId") Long userId) {
         Optional<User> userOptional = userService.getOne(userId);


### PR DESCRIPTION
Security issue due to Broken Access Control on UserController.java
Changed required role from ROLE_USER to ROLE_ADMIN on `/v1/users` and` /v1/users/{userId}` endpoints.
It's possible to obtain sensitive information just by making a GET request on any of those endpoints by setting the Authorization header from a non-admin user. 

Also, please note that this pull request is part of a project for a university subject, so I'd really appreciate if you could review and approve it if you consider it useful. 